### PR TITLE
Adding the option to skip already processed images when processing the whole vault

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,10 +6,11 @@
 	"packages": {
 		"": {
 			"name": "image-converter",
-			"version": "1.1.6",
+			"version": "1.1.7",
 			"license": "MIT",
 			"dependencies": {
-				"heic-convert": "^1.2.4"
+				"heic-convert": "^1.2.4",
+				"probe-image-size": "^7.2.3"
 			},
 			"devDependencies": {
 				"@types/node": "^16.11.6",
@@ -1507,6 +1508,17 @@
 				"node": ">=8.0.0"
 			}
 		},
+		"node_modules/iconv-lite": {
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/ignore": {
 			"version": "5.2.4",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
@@ -1698,9 +1710,7 @@
 		"node_modules/lodash.merge": {
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-			"dev": true,
-			"peer": true
+			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
 		},
 		"node_modules/lru-cache": {
 			"version": "6.0.0",
@@ -1761,8 +1771,7 @@
 		"node_modules/ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"node_modules/natural-compare": {
 			"version": "1.4.0",
@@ -1770,6 +1779,30 @@
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true,
 			"peer": true
+		},
+		"node_modules/needle": {
+			"version": "2.9.1",
+			"resolved": "https://registry.npmjs.org/needle/-/needle-2.9.1.tgz",
+			"integrity": "sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==",
+			"dependencies": {
+				"debug": "^3.2.6",
+				"iconv-lite": "^0.4.4",
+				"sax": "^1.2.4"
+			},
+			"bin": {
+				"needle": "bin/needle"
+			},
+			"engines": {
+				"node": ">= 4.4.x"
+			}
+		},
+		"node_modules/needle/node_modules/debug": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+			"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+			"dependencies": {
+				"ms": "^2.1.1"
+			}
 		},
 		"node_modules/obsidian": {
 			"version": "1.4.4",
@@ -1927,6 +1960,16 @@
 				"node": ">= 0.8.0"
 			}
 		},
+		"node_modules/probe-image-size": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-7.2.3.tgz",
+			"integrity": "sha512-HubhG4Rb2UH8YtV4ba0Vp5bQ7L78RTONYu/ujmCu5nBI8wGv24s4E9xSKBi0N1MowRpxk76pFCpJtW0KPzOK0w==",
+			"dependencies": {
+				"lodash.merge": "^4.6.2",
+				"needle": "^2.5.2",
+				"stream-parser": "~0.3.1"
+			}
+		},
 		"node_modules/punycode": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
@@ -2028,6 +2071,16 @@
 				"queue-microtask": "^1.2.2"
 			}
 		},
+		"node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+		},
+		"node_modules/sax": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.3.0.tgz",
+			"integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA=="
+		},
 		"node_modules/semver": {
 			"version": "7.5.4",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
@@ -2074,6 +2127,27 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/stream-parser": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/stream-parser/-/stream-parser-0.3.1.tgz",
+			"integrity": "sha512-bJ/HgKq41nlKvlhccD5kaCr/P+Hu0wPNKPJOH7en+YrJu/9EgqUF+88w5Jb6KNcjOFMhfX4B2asfeAtIGuHObQ==",
+			"dependencies": {
+				"debug": "2"
+			}
+		},
+		"node_modules/stream-parser/node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/stream-parser/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
 		},
 		"node_modules/strip-ansi": {
 			"version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"typescript": "4.7.4"
 	},
 	"dependencies": {
-		"heic-convert": "^1.2.4"
+		"heic-convert": "^1.2.4",
+		"probe-image-size": "^7.2.3"
 	}
 }


### PR DESCRIPTION
This PR adds the option to skip all images, which already are in the target format.  
This is especially useful if you have a very large vault with many images, and converting them all takes hours. Then you can use this option to skip any already processed images, and don't have to start from 0 if for whatever reason the process gets stopped.

Additionally, I moved the log statement to the beginning of the function, I had the problem where the image processing threw an error and the log line did not get called anymore, so I was not able to see which image caused the problem.

Also, it seems like the dependency to `probe-image-size` was missing, so I added that as well.

<img width="596" alt="Screenshot 2024-01-26 at 17 39 53" src="https://github.com/xRyul/obsidian-image-converter/assets/29383712/6fc77191-5bf5-4774-914c-14c89e92d197">
