### PR TITLE
Support ${filename} regex replace on attachment location

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -890,7 +890,8 @@ export default class ImageConvertPLugin extends Plugin {
 				break;
 
 			case 'subfolder':
-				newPath = activeFile.path.substring(0, activeFile.path.lastIndexOf('/')) + '/' + this.settings.attachmentSubfolderName;
+				let transAttachmentSubFolderName = this.settings.attachmentSubfolderName.replace(/\${filename}/g, activeFile.basename)
+				newPath = activeFile.path.substring(0, activeFile.path.lastIndexOf('/')) + '/' + transAttachmentSubFolderName;
 				break;
 			default:
 				newPath = '/';


### PR DESCRIPTION
In this PR, image-convertor will Automatically parse and replace some marco like '${filename}' to current activate file'filename withour extension. 
![image](https://github.com/xRyul/obsidian-image-converter/assets/46283762/9931bc5a-f200-41f2-83d2-956eeb004709)

With this modification, I can get rid of this plugin [Custom Attachment Location](https://github.com/RainCat1998/obsidian-custom-attachment-location), which has the same functionality but implemented by modify obisidion's configuration in each time.

