### PR TITLE
fix: fix a small spelling error (wether -> whether)

### DIFF
--- a/src/ImageConverterSettings.ts
+++ b/src/ImageConverterSettings.ts
@@ -482,7 +482,7 @@ export class ImageConverterSettingTab extends PluginSettingTab {
 
         new Setting(containerEl)
             .setName("Show window")
-            .setDesc("Choose wether to show processing options on each image drop/paste")
+            .setDesc("Choose whether to show processing options on each image drop/paste")
             .addDropdown((dropdown) => {
                 dropdown
                     .addOption("always", "Always show")


### PR DESCRIPTION
As the title suggests.

Corrected a minor spelling mistake in the `ImageConverterSettings.ts` file.  The description for the processing options setting now correctly uses "whether" instead of "wether".

Have a nice day!