### PR TITLE
Add variable parentparentfolder and notename_nospaces

### DIFF
--- a/Examples/Variables Reference Guide.md
+++ b/Examples/Variables Reference Guide.md
@@ -21,7 +21,7 @@ This document provides a detailed explanation of all available variables for the
 - `{notename_nospaces}` - Current note name with underscores replacing spaces eg.: "Travel Log" → "Travel_Log" 
 - `{fileType}` - File extension e.g.: "jpg", "png", "pdf"
 - `{parentFolder}` - Parent folder name e.g.: In "Documents/Photos/Vacation" → "Photos"
-- `{parentparentfolder}` - Grandparent folder name e.g.: "Documents/Photos/Vacation" → "Documents"
+- `{grandparentfolder}` - Grandparent folder name e.g.: "Documents/Photos/Vacation" → "Documents"
 - `{directory}` - Full directory path e.g.: "Documents/Photos/Vacation"
 - `{folderName}` - Current folder name e.g.: In "Documents/Photos/Vacation" → "Vacation"
 - `{depth}` - Number of subfolder levels e.g.: "Documents/Photos/Vacation" → "3"

--- a/Examples/Variables Reference Guide.md
+++ b/Examples/Variables Reference Guide.md
@@ -20,6 +20,7 @@ This document provides a detailed explanation of all available variables for the
 - `{noteName}` - Current note name e.g.: If editing "Travel Log.md" → "Travel Log"
 - `{fileType}` - File extension e.g.: "jpg", "png", "pdf"
 - `{parentFolder}` - Parent folder name e.g.: In "Documents/Photos/Vacation" → "Photos"
+- `{parentparentfolder}` - Grandparent folder name e.g.: "Documents/Photos/Vacation" → "Documents"
 - `{directory}` - Full directory path e.g.: "Documents/Photos/Vacation"
 - `{folderName}` - Current folder name e.g.: In "Documents/Photos/Vacation" → "Vacation"
 - `{depth}` - Number of subfolder levels e.g.: "Documents/Photos/Vacation" → "3"

--- a/Examples/Variables Reference Guide.md
+++ b/Examples/Variables Reference Guide.md
@@ -18,6 +18,7 @@ This document provides a detailed explanation of all available variables for the
 
 - `{imageName}` - Original image filename without extension e.g.: For "vacation-photo.jpg" → "vacation-photo"
 - `{noteName}` - Current note name e.g.: If editing "Travel Log.md" → "Travel Log"
+- `{notename_nospaces}` - Current note name with underscores replacing spaces eg.: "Travel Log" → "Travel_Log" 
 - `{fileType}` - File extension e.g.: "jpg", "png", "pdf"
 - `{parentFolder}` - Parent folder name e.g.: In "Documents/Photos/Vacation" → "Photos"
 - `{parentparentfolder}` - Grandparent folder name e.g.: "Documents/Photos/Vacation" → "Documents"

--- a/src/VariableProcessor.ts
+++ b/src/VariableProcessor.ts
@@ -291,6 +291,11 @@ export class VariableProcessor {
             description: "The name of the immediate parent folder of the note.",
             example: "Project",
         },
+		{
+			name: "{parentparentfolder}",
+			description: "Parent of the parent folder of the note, but not the vault root",
+			example: "ParentOfProject"
+		},
         {
             name: "{notefolder}",
             description: "The name of the immediate parent folder of the note.",
@@ -513,7 +518,7 @@ export class VariableProcessor {
         for (const variable of variables) {
             if (variable.name.startsWith("{date") || ["{YYYY}", "{MM}", "{DD}", "{HH}", "{mm}", "{ss}", "{weekday}", "{month}", "{calendar}", "{today}", "{YYYY-MM-DD}", "{tomorrow}", "{yesterday}", "{startofweek}", "{endofweek}", "{startofmonth}", "{endofmonth}", "{nextweek}", "{lastweek}", "{nextmonth}", "{lastmonth}", "{daysinmonth}", "{weekofyear}", "{quarterofyear}", "{week}", "{w}", "{quarter}", "{Q}", "{dayofyear}", "{DDD}", "{monthname}", "{MMMM}", "{dayname}", "{dddd}", "{dateordinal}", "{Do}", "{relativetime}", "{currentdate}", "{yyyy}", "{time}", "{timestamp}"].includes(variable.name)) {
                 categorized["Date & Time"].push(variable);
-            } else if (["{vaultname}", "{vaultpath}", "{parentfolder}", "{notefolder}", "{notepath}"].includes(variable.name)) {
+            } else if (["{vaultname}", "{vaultpath}", "{parentfolder}", "{parentparentfolder}" ,"{notefolder}", "{notepath}"].includes(variable.name)) {
                 categorized["File & Vault"].push(variable);
             } else if (["{imagename}", "{filetype}", "{sizeb}", "{sizekb}", "{sizemb}", "{notename}"].includes(variable.name)) {
                 categorized["Basic"].push(variable);
@@ -599,6 +604,7 @@ export class VariableProcessor {
         variables["{notename}"] = activeFile.basename;
         variables["{notepath}"] = activeFile.path;
         variables["{parentfolder}"] = activeFile.parent?.name || "";
+        variables["{parentparentfolder}"] = (activeFile.parent?.parent?.path == "/" ? activeFile.parent?.name : activeFile.parent?.parent?.name) || "";
         variables["{notefolder}"] = activeFile.parent?.name || "";
         variables["{vaultname}"] = this.app.vault.getName();
         variables["{vaultpath}"] = this.app.vault.getRoot().path;
@@ -771,6 +777,9 @@ export class VariableProcessor {
                 case "parentfolder":
                     textToHash = activeFile.parent?.name || "";
                     break;
+                case "parentparentfolder":
+                    textToHash = (activeFile.parent?.parent?.path == "/" ? activeFile.parent?.name : activeFile.parent?.parent?.name) || "";
+                    break;
                 case "rootfolder":
                     textToHash = this.app.vault.getRoot().path;
                     break;
@@ -823,6 +832,9 @@ export class VariableProcessor {
                     }
                     case "parentfolder":
                         textToHash = activeFile.parent?.name || "";
+                        break;
+                    case "parentparentfolder":
+                        textToHash = (activeFile.parent?.parent?.path == "/" ? activeFile.parent?.name : activeFile.parent?.parent?.name) || "";
                         break;
                     case "rootfolder":
                         textToHash = this.app.vault.getRoot().path;

--- a/src/VariableProcessor.ts
+++ b/src/VariableProcessor.ts
@@ -297,7 +297,7 @@ export class VariableProcessor {
             example: "Project",
         },
 		{
-			name: "{parentparentfolder}",
+			name: "{grandparentfolder}",
 			description: "Parent of the parent folder of the note, but not the vault root",
 			example: "ParentOfProject"
 		},
@@ -523,7 +523,7 @@ export class VariableProcessor {
         for (const variable of variables) {
             if (variable.name.startsWith("{date") || ["{YYYY}", "{MM}", "{DD}", "{HH}", "{mm}", "{ss}", "{weekday}", "{month}", "{calendar}", "{today}", "{YYYY-MM-DD}", "{tomorrow}", "{yesterday}", "{startofweek}", "{endofweek}", "{startofmonth}", "{endofmonth}", "{nextweek}", "{lastweek}", "{nextmonth}", "{lastmonth}", "{daysinmonth}", "{weekofyear}", "{quarterofyear}", "{week}", "{w}", "{quarter}", "{Q}", "{dayofyear}", "{DDD}", "{monthname}", "{MMMM}", "{dayname}", "{dddd}", "{dateordinal}", "{Do}", "{relativetime}", "{currentdate}", "{yyyy}", "{time}", "{timestamp}"].includes(variable.name)) {
                 categorized["Date & Time"].push(variable);
-            } else if (["{vaultname}", "{vaultpath}", "{parentfolder}", "{parentparentfolder}" ,"{notefolder}", "{notepath}"].includes(variable.name)) {
+            } else if (["{vaultname}", "{vaultpath}", "{parentfolder}", "{grandparentfolder}" ,"{notefolder}", "{notepath}"].includes(variable.name)) {
                 categorized["File & Vault"].push(variable);
             } else if (["{imagename}", "{filetype}", "{sizeb}", "{sizekb}", "{sizemb}", "{notename}", "{notename_nospaces}"].includes(variable.name)) {
                 categorized["Basic"].push(variable);
@@ -610,7 +610,7 @@ export class VariableProcessor {
         variables["{notename_nospaces}"] = activeFile.basename.replace(/\s+/g, "_");
         variables["{notepath}"] = activeFile.path;
         variables["{parentfolder}"] = activeFile.parent?.name || "";
-        variables["{parentparentfolder}"] = (activeFile.parent?.parent?.path == "/" ? activeFile.parent?.name : activeFile.parent?.parent?.name) || "";
+        variables["{grandparentfolder}"] = (activeFile.parent?.parent?.path == "/" ? activeFile.parent?.name : activeFile.parent?.parent?.name) || "";
         variables["{notefolder}"] = activeFile.parent?.name || "";
         variables["{vaultname}"] = this.app.vault.getName();
         variables["{vaultpath}"] = this.app.vault.getRoot().path;
@@ -783,7 +783,7 @@ export class VariableProcessor {
                 case "parentfolder":
                     textToHash = activeFile.parent?.name || "";
                     break;
-                case "parentparentfolder":
+                case "grandparentfolder":
                     textToHash = (activeFile.parent?.parent?.path == "/" ? activeFile.parent?.name : activeFile.parent?.parent?.name) || "";
                     break;
                 case "rootfolder":
@@ -842,7 +842,7 @@ export class VariableProcessor {
                     case "parentfolder":
                         textToHash = activeFile.parent?.name || "";
                         break;
-                    case "parentparentfolder":
+                    case "grandparentfolder":
                         textToHash = (activeFile.parent?.parent?.path == "/" ? activeFile.parent?.name : activeFile.parent?.parent?.name) || "";
                         break;
                     case "rootfolder":

--- a/src/VariableProcessor.ts
+++ b/src/VariableProcessor.ts
@@ -57,6 +57,11 @@ export class VariableProcessor {
             description: "The name of the current note.",
             example: "MeetingNotes",
         },
+        {
+            name: "{notename_nospaces}",
+            description: "The name of the current note with spaces replaced by underscores.",
+            example: "Meeting_Notes",
+        },
 
         // Date & Time
         {
@@ -520,7 +525,7 @@ export class VariableProcessor {
                 categorized["Date & Time"].push(variable);
             } else if (["{vaultname}", "{vaultpath}", "{parentfolder}", "{parentparentfolder}" ,"{notefolder}", "{notepath}"].includes(variable.name)) {
                 categorized["File & Vault"].push(variable);
-            } else if (["{imagename}", "{filetype}", "{sizeb}", "{sizekb}", "{sizemb}", "{notename}"].includes(variable.name)) {
+            } else if (["{imagename}", "{filetype}", "{sizeb}", "{sizekb}", "{sizemb}", "{notename}", "{notename_nospaces}"].includes(variable.name)) {
                 categorized["Basic"].push(variable);
             } else if (["{width}", "{height}", "{aspectratio}", "{orientation}", "{resolution}"].includes(variable.name)) {
                 categorized["Image Metadata"].push(variable);
@@ -602,6 +607,7 @@ export class VariableProcessor {
         }
 
         variables["{notename}"] = activeFile.basename;
+        variables["{notename_nospaces}"] = activeFile.basename.replace(/\s+/g, "_");
         variables["{notepath}"] = activeFile.path;
         variables["{parentfolder}"] = activeFile.parent?.name || "";
         variables["{parentparentfolder}"] = (activeFile.parent?.parent?.path == "/" ? activeFile.parent?.name : activeFile.parent?.parent?.name) || "";
@@ -789,6 +795,9 @@ export class VariableProcessor {
                 case "notename":
                     textToHash = activeFile.basename;
                     break;
+                case "notename_nospaces":
+                    textToHash = activeFile.basename.replace(/\s+/g, "_");
+                    break;
                 case "notefolder":
                     textToHash = activeFile.parent?.name || "";
                     break;
@@ -844,6 +853,9 @@ export class VariableProcessor {
                         break;
                     case "notename":
                         textToHash = activeFile.basename;
+                        break;
+                    case "notename_nospaces":
+                        textToHash = activeFile.basename.replace(/\s+/g, "_");
                         break;
                     case "notefolder":
                         textToHash = activeFile.parent?.name || "";


### PR DESCRIPTION
\+ Add variable `parentparentfolder` to climb 2 directories, or 1 if 2 would be the vault root.
\+ Add variable `notename_nospaces` as requested in issue https://github.com/xRyul/obsidian-image-converter/issues/106

Backstory for `parentparentfolder`: 
I found myself needing a variable to climb up 1-2 directories, but never placing in the vault root. 
My specific use case is:
- Topic 1:
    - Pictures
    - Subtopic 1
        - Item 1
        - Item 2
    - Item 3 
Where I wish to place all images in a specific folder under each topic, but not per subtopic. 