### PR TITLE
added setting and functionality to keep image aspect ratio fixed 

### DIFF
--- a/src/ImageConverterSettings.ts
+++ b/src/ImageConverterSettings.ts
@@ -184,6 +184,7 @@ export interface ImageConverterSettings {
     imageAlignment_cacheLocation: ".obsidian" | "plugin";
 
     isDragResizeEnabled: boolean;
+    isDragAspectRatioFixed: boolean;
     isScrollResizeEnabled: boolean;
     isResizeInReadingModeEnabled: boolean;
 
@@ -377,6 +378,7 @@ export const DEFAULT_SETTINGS: ImageConverterSettings = {
 
     isDragResizeEnabled: true,
     isScrollResizeEnabled: true,
+    isDragAspectRatioFixed: false,
     isResizeInReadingModeEnabled: false,
 
     resizeSensitivity: 0.1,
@@ -911,8 +913,27 @@ export class ImageConverterSettingTab extends PluginSettingTab {
                         .onChange(async (value) => {
                             this.plugin.settings.isDragResizeEnabled = value;
                             await this.plugin.saveSettings();
+                            // Force refresh to update visible options
+                            this.display();                            
                         })
                 );
+
+            // Drag-resize specific settings - only show when drag resize is enabled
+            if (this.plugin.settings.isDragResizeEnabled) {
+                const apectRatioSettingsContainer = imageDragResizeSection.createDiv('fix-aspect-ratio-settings');
+
+                new Setting(apectRatioSettingsContainer)
+                    .setName('Lock the aspect ratio when dragging')
+                    .setDesc('Prevent acccidental distortions of image aspect ratio when dragging to resize')
+                    .addToggle(toggle => toggle
+                        .setValue(this.plugin.settings.isDragAspectRatioFixed)
+                        .onChange(async (value) => {
+                            this.plugin.settings.isDragAspectRatioFixed = value;
+                            await this.plugin.saveSettings();
+
+                        }));
+            }
+
 
             new Setting(imageDragResizeSection)
                 .setName('Enable scroll-wheel resize')

--- a/src/ImageResizer.ts
+++ b/src/ImageResizer.ts
@@ -492,18 +492,40 @@ export class ImageResizer {
                 newHeight = Math.max(minSize, this.initialHeight * scaleFactor);
             } else {
                 // Handle-based resizing (internal images)
+                const isAspectFixed = this.plugin.settings.isDragAspectRatioFixed;
+ 
                 switch (this.currentHandle) {
                     case 'n': // Top handle: adjust height from the top
-                        newHeight = Math.max(minSize, this.initialHeight - deltaY);
+                        if (isAspectFixed) {
+                            newHeight = Math.max(minSize, this.initialHeight - deltaY);
+                            newWidth = newHeight * this.initialAspectRatio;
+                        } else{
+                            newHeight = Math.max(minSize, this.initialHeight - deltaY);
+                        } 
                         break;
                     case 's': // Bottom handle: adjust height from the bottom
-                        newHeight = Math.max(minSize, this.initialHeight + deltaY);
+                        if (isAspectFixed) {
+                            newHeight = Math.max(minSize, this.initialHeight + deltaY);
+                            newWidth = newHeight * this.initialAspectRatio;
+                        } else{                    
+                            newHeight = Math.max(minSize, this.initialHeight + deltaY);
+                        }
                         break;
                     case 'e': // Right handle: adjust width from the right
-                        newWidth = Math.max(minSize, this.initialWidth + deltaX);
+                        if (isAspectFixed) {      
+                            newWidth = Math.max(minSize, this.initialWidth + deltaX);
+                            newHeight = newWidth / this.initialAspectRatio;
+                        } else{                    
+                            newWidth = Math.max(minSize, this.initialWidth + deltaX);
+                        }
                         break;
                     case 'w': // Left handle: adjust width from the left
-                        newWidth = Math.max(minSize, this.initialWidth - deltaX);
+                        if (isAspectFixed) {
+                            newWidth = Math.max(minSize, this.initialWidth - deltaX);
+                            newHeight = newWidth / this.initialAspectRatio;
+                        } else{                    
+                            newWidth = Math.max(minSize, this.initialWidth - deltaX);
+                        }
                         break;
                     case 'nw': // Top-left handle: adjust width and maintain aspect ratio
                     case 'sw': // Bottom-left handle: adjust width and maintain aspect ratio


### PR DESCRIPTION
Hey xRyul!
I actually created an [issue](https://github.com/xRyul/obsidian-image-converter/issues/245) to add a feature to keep the aspect ratio locked for images when resizing them.
I mostly use obsidian for integrating my physical text scans into my digital notes, so destructive scaling is a bit of an issue for me. 

I went over your source code and its really well maintained so i just wrote the functionality myself :D

I added an option to lock the aspect ratio of the image in the settings. 

not a lot of changes and mostly just reused the code that you have written so reviewing shouldnt be much of an issue

Thanks again for the great plugin!