### PR TITLE
Feat/compress threshold

### DIFF
--- a/src/ImageConverterSettings.ts
+++ b/src/ImageConverterSettings.ts
@@ -205,6 +205,7 @@ export interface ImageConverterSettings {
 
     showSpaceSavedNotification: boolean;
     revertToOriginalIfLarger: boolean;
+    minimumCompressionSavingsInKB: number;
 
     enableImageCaptions: boolean;
     skipCaptionExtensions: string;
@@ -394,6 +395,7 @@ export const DEFAULT_SETTINGS: ImageConverterSettings = {
 
     showSpaceSavedNotification: true,
     revertToOriginalIfLarger: false,
+    minimumCompressionSavingsInKB: 30,
 
     enableImageCaptions: true,
     skipCaptionExtensions: "icns",
@@ -2462,6 +2464,27 @@ export class ImageConverterSettingTab extends PluginSettingTab {
             newSetting.settingEl
         );
         lastAddedSetting = newSetting.settingEl;
+
+        const minSavingsSetting = new Setting(containerEl)
+            .setName("Minimum compression savings (KB)")
+            .setDesc("If 0, compress whenever size decreases. Otherwise, requires savings > this value (KB). Only effective when 'Revert to original if larger' is enabled.")
+            .addText((text) =>
+                text
+                    .setPlaceholder("30")
+                    .setValue(String(this.plugin.settings.minimumCompressionSavingsInKB))
+                    .onChange(async (value) => {
+                        const numValue = Number(value);
+                        if (!isNaN(numValue) && numValue >= 0) {
+                            this.plugin.settings.minimumCompressionSavingsInKB = numValue;
+                            await this.plugin.saveSettings();
+                        }
+                    })
+            );
+        lastAddedSetting.insertAdjacentElement(
+            "afterend",
+            minSavingsSetting.settingEl
+        );
+        lastAddedSetting = minSavingsSetting.settingEl;
     }
 
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -724,8 +724,7 @@ export default class ImageConverterPlugin extends Plugin {
                             // Step 3.5.4: Create the Image File in Vault
                             // - Create the new image file in the Obsidian vault using `createBinary`.
                             // Show space savings notification
-                            // Check if processed image is larger than original
-                            // 如果大于原图的30KB则视为更大，那也不压缩——说明压缩的量小于 30kb
+                            // Check if processed image is larger than original + minimum savings
                             const minSavingsKB = (typeof this.settings.minimumCompressionSavingsInKB === 'number' && this.settings.minimumCompressionSavingsInKB >= 0)
                                 ? this.settings.minimumCompressionSavingsInKB
                                 : 30;
@@ -733,7 +732,7 @@ export default class ImageConverterPlugin extends Plugin {
                             if (this.settings.revertToOriginalIfLarger && this.processedImage.byteLength + (minSavingsKB * 1024) > originalSize) {
                                 // User wants to revert AND processed image is larger
                                 this.showSizeComparisonNotification(originalSize, this.processedImage.byteLength);
-                                new Notice(`Using original image for "${file.name}" as processed image is larger / compress less than ${minSavingsKB}KB.`);
+                                new Notice(`Using original image for "${file.name}" as processed image is larger / saving less than ${minSavingsKB}KB.`);
 
                                 const fileBuffer = await file.arrayBuffer();
                                 tfile = await this.app.vault.createBinary(newFullPath, fileBuffer) as TFile;
@@ -1038,8 +1037,7 @@ export default class ImageConverterPlugin extends Plugin {
                             // Step 3.5.4: Create the Image File in Vault
                             // - Create the new image file in the Obsidian vault using `createBinary`.
                             // - Show space savings notification
-                            // Check if processed image is larger than original
-                            // 如果大于原图的30KB则视为更大，那也不压缩——说明压缩的量小于 30kb
+                            // Check if processed image is larger than original + minimum savings
                             const minSavingsKB = (typeof this.settings.minimumCompressionSavingsInKB === 'number' && this.settings.minimumCompressionSavingsInKB >= 0)
                                 ? this.settings.minimumCompressionSavingsInKB
                                 : 30;
@@ -1047,7 +1045,7 @@ export default class ImageConverterPlugin extends Plugin {
                             if (this.settings.revertToOriginalIfLarger && this.processedImage.byteLength + (minSavingsKB * 1024) > originalSize) {
                                 // User wants to revert AND processed image is larger
                                 this.showSizeComparisonNotification(originalSize, this.processedImage.byteLength);
-                                new Notice(`Using original image for "${file.name}" as processed image is larger / compress less than ${minSavingsKB}KB.`);
+                                new Notice(`Using original image for "${file.name}" as processed image is larger / saving less than ${minSavingsKB}KB.`);
 
                                 const fileBuffer = await file.arrayBuffer();
                                 tfile = await this.app.vault.createBinary(newFullPath, fileBuffer) as TFile;

--- a/src/main.ts
+++ b/src/main.ts
@@ -726,10 +726,14 @@ export default class ImageConverterPlugin extends Plugin {
                             // Show space savings notification
                             // Check if processed image is larger than original
                             // 如果大于原图的30KB则视为更大，那也不压缩——说明压缩的量小于 30kb
-                            if (this.settings.revertToOriginalIfLarger && this.processedImage.byteLength + 30720 > originalSize) {
+                            const minSavingsKB = (typeof this.settings.minimumCompressionSavingsInKB === 'number' && this.settings.minimumCompressionSavingsInKB >= 0)
+                                ? this.settings.minimumCompressionSavingsInKB
+                                : 30;
+
+                            if (this.settings.revertToOriginalIfLarger && this.processedImage.byteLength + (minSavingsKB * 1024) > originalSize) {
                                 // User wants to revert AND processed image is larger
                                 this.showSizeComparisonNotification(originalSize, this.processedImage.byteLength);
-                                new Notice(`Using original image for "${file.name}" as processed image is larger / compress less than 30KB.`);
+                                new Notice(`Using original image for "${file.name}" as processed image is larger / compress less than ${minSavingsKB}KB.`);
 
                                 const fileBuffer = await file.arrayBuffer();
                                 tfile = await this.app.vault.createBinary(newFullPath, fileBuffer) as TFile;
@@ -1036,10 +1040,14 @@ export default class ImageConverterPlugin extends Plugin {
                             // - Show space savings notification
                             // Check if processed image is larger than original
                             // 如果大于原图的30KB则视为更大，那也不压缩——说明压缩的量小于 30kb
-                            if (this.settings.revertToOriginalIfLarger && this.processedImage.byteLength + 30720 > originalSize) {
+                            const minSavingsKB = (typeof this.settings.minimumCompressionSavingsInKB === 'number' && this.settings.minimumCompressionSavingsInKB >= 0)
+                                ? this.settings.minimumCompressionSavingsInKB
+                                : 30;
+
+                            if (this.settings.revertToOriginalIfLarger && this.processedImage.byteLength + (minSavingsKB * 1024) > originalSize) {
                                 // User wants to revert AND processed image is larger
                                 this.showSizeComparisonNotification(originalSize, this.processedImage.byteLength);
-                                new Notice(`Using original image for "${file.name}" as processed image is larger / compress less than 30KB.`);
+                                new Notice(`Using original image for "${file.name}" as processed image is larger / compress less than ${minSavingsKB}KB.`);
 
                                 const fileBuffer = await file.arrayBuffer();
                                 tfile = await this.app.vault.createBinary(newFullPath, fileBuffer) as TFile;

--- a/src/main.ts
+++ b/src/main.ts
@@ -725,10 +725,11 @@ export default class ImageConverterPlugin extends Plugin {
                             // - Create the new image file in the Obsidian vault using `createBinary`.
                             // Show space savings notification
                             // Check if processed image is larger than original
-                            if (this.settings.revertToOriginalIfLarger && this.processedImage.byteLength > originalSize) {
+                            // 如果大于原图的30KB则视为更大，那也不压缩——说明压缩的量小于 30kb
+                            if (this.settings.revertToOriginalIfLarger && this.processedImage.byteLength + 30720 > originalSize) {
                                 // User wants to revert AND processed image is larger
                                 this.showSizeComparisonNotification(originalSize, this.processedImage.byteLength);
-                                new Notice(`Using original image for "${file.name}" as processed image is larger.`);
+                                new Notice(`Using original image for "${file.name}" as processed image is larger / compress less than 30KB.`);
 
                                 const fileBuffer = await file.arrayBuffer();
                                 tfile = await this.app.vault.createBinary(newFullPath, fileBuffer) as TFile;
@@ -1034,10 +1035,11 @@ export default class ImageConverterPlugin extends Plugin {
                             // - Create the new image file in the Obsidian vault using `createBinary`.
                             // - Show space savings notification
                             // Check if processed image is larger than original
-                            if (this.settings.revertToOriginalIfLarger && this.processedImage.byteLength > originalSize) {
+                            // 如果大于原图的30KB则视为更大，那也不压缩——说明压缩的量小于 30kb
+                            if (this.settings.revertToOriginalIfLarger && this.processedImage.byteLength + 30720 > originalSize) {
                                 // User wants to revert AND processed image is larger
                                 this.showSizeComparisonNotification(originalSize, this.processedImage.byteLength);
-                                new Notice(`Using original image for "${file.name}" as processed image is larger.`);
+                                new Notice(`Using original image for "${file.name}" as processed image is larger / compress less than 30KB.`);
 
                                 const fileBuffer = await file.arrayBuffer();
                                 tfile = await this.app.vault.createBinary(newFullPath, fileBuffer) as TFile;


### PR DESCRIPTION
Hey, Thank you for considering this feature!

I add a setting for it:
<img width="774" height="371" alt="Snipaste_2026-01-15_17-08-14" src="https://github.com/user-attachments/assets/1503ed27-385e-4099-84ae-486e57195ec0" />

And the default value is 30 (kb).

I originally planned to make it so that "this additional configuration is only displayed when the switch above is turned on," but I was concerned that the implementation approach might not be optimal, so I held off for now and only explained it in the comments.
