### PR TITLE
feat(process-current-note): add skip folders support

### DIFF
--- a/src/BatchImageProcessor.ts
+++ b/src/BatchImageProcessor.ts
@@ -59,7 +59,8 @@ export class BatchImageProcessor {
                 ProcessCurrentNoteEnlargeOrReduce: enlargeOrReduce,
                 allowLargerFiles,
                 ProcessCurrentNoteSkipFormats: processCurrentNoteSkipFormats,
-                ProcessCurrentNoteskipImagesInTargetFormat: processCurrentNoteSkipImagesInTargetFormat
+                ProcessCurrentNoteskipImagesInTargetFormat: processCurrentNoteSkipImagesInTargetFormat,
+                ProcessCurrentNoteIgnoreFolders: processCurrentNoteIgnoreFolders = ""
             } = this.plugin.settings;
 
             const isKeepOriginalFormat = convertTo === 'disabled';
@@ -94,6 +95,13 @@ export class BatchImageProcessor {
                 seen.add(file.path);
                 return true;
             });
+
+            // Filter out ignored folders
+            if (processCurrentNoteIgnoreFolders.trim()) {
+                linkedFiles = linkedFiles.filter(
+                    (file) => !this.folderAndFilenameManagement.matchesPathPatterns(file.path, processCurrentNoteIgnoreFolders)
+                );
+            }
 
             // If no images found at all
             if (linkedFiles.length === 0) {

--- a/src/FolderAndFilenameManagement.ts
+++ b/src/FolderAndFilenameManagement.ts
@@ -513,41 +513,113 @@ export class FolderAndFilenameManagement {
             .map((part) => part.trim())
             .filter((part) => part.length > 0);
 
+        return patterns.some((pattern) => this.matchesPattern(filename, pattern));
+    }
+
+    matchesPathPatterns(path: string, patternsString: string): boolean {
+        if (!patternsString.trim()) {
+            return false;
+        }
+
+        const normalizedPath = normalizePath(path)
+            .replace(/^\.[/\\]+/, "")
+            .replace(/^\//, "");
+        const patterns = patternsString
+            .split(",")
+            .map((part) => part.trim())
+            .filter((part) => part.length > 0);
+
         return patterns.some((pattern) => {
-            try {
-                // Check if pattern is a regex (enclosed in /)
-                if (pattern.startsWith("/") && pattern.endsWith("/")) {
-                    // Extract regex pattern without the slashes
-                    const regexPattern = pattern.slice(1, -1);
-                    const regex = new RegExp(regexPattern, "i");
-                    return regex.test(filename);
-                }
-                // Check if pattern is a regex (enclosed in r/)
-                if (pattern.startsWith("r/") && pattern.endsWith("/")) {
-                    // Extract regex pattern without r/ and /
-                    const regexPattern = pattern.slice(2, -1);
-                    const regex = new RegExp(regexPattern, "i");
-                    return regex.test(filename);
-                }
-                // Check if pattern is a regex (enclosed in regex:)
-                if (pattern.startsWith("regex:")) {
-                    // Extract regex pattern without regex:
-                    const regexPattern = pattern.slice(6);
-                    const regex = new RegExp(regexPattern, "i");
-                    return regex.test(filename);
-                }
-                // Default to glob pattern
-                const globPattern = pattern
-                    .replace(/\./g, "\\.")
-                    .replace(/\*/g, ".*")
-                    .replace(/\?/g, ".");
-                const regex = new RegExp(`^${globPattern}$`, "i");
-                return regex.test(filename);
-            } catch (e) {
-                console.error(`Invalid pattern: ${pattern}`, e);
-                return false;
+            const normalizedPattern = this.normalizePathPattern(pattern);
+
+            if (this.matchesFolderPrefixPattern(normalizedPath, normalizedPattern)) {
+                return true;
             }
+
+            if (this.matchesPattern(normalizedPath, normalizedPattern)) {
+                return true;
+            }
+
+            if (this.isPlainFolderPattern(normalizedPattern)) {
+                return normalizedPath === normalizedPattern
+                    || normalizedPath.startsWith(`${normalizedPattern}/`);
+            }
+
+            return false;
         });
+    }
+
+    private normalizePathPattern(pattern: string): string {
+        if (this.isRegexPattern(pattern)) {
+            return pattern;
+        }
+
+        return normalizePath(pattern)
+            .replace(/^\.[/\\]+/, "")
+            .replace(/^\//, "");
+    }
+
+    private matchesFolderPrefixPattern(pathValue: string, pattern: string): boolean {
+        const normalizedPattern = pattern.replace(/\/\*\*\/?$/, "");
+        if (pattern.endsWith("/**") && normalizedPattern.length > 0 && this.isPlainFolderPattern(normalizedPattern)) {
+            return pathValue === normalizedPattern || pathValue.startsWith(`${normalizedPattern}/`);
+        }
+        return false;
+    }
+
+    private matchesPattern(filename: string, pattern: string): boolean {
+        try {
+            // Check if pattern is a regex (enclosed in /)
+            if (pattern.startsWith("/") && pattern.endsWith("/")) {
+                // Extract regex pattern without the slashes
+                const regexPattern = pattern.slice(1, -1);
+                const regex = new RegExp(regexPattern, "i");
+                return regex.test(filename);
+            }
+            // Check if pattern is a regex (enclosed in r/)
+            if (pattern.startsWith("r/") && pattern.endsWith("/")) {
+                // Extract regex pattern without r/ and /
+                const regexPattern = pattern.slice(2, -1);
+                const regex = new RegExp(regexPattern, "i");
+                return regex.test(filename);
+            }
+            // Check if pattern is a regex (enclosed in regex:)
+            if (pattern.startsWith("regex:")) {
+                // Extract regex pattern without regex:
+                const regexPattern = pattern.slice(6);
+                const regex = new RegExp(regexPattern, "i");
+                return regex.test(filename);
+            }
+            // Default to glob pattern
+            // Handle ** (match any characters including /) before * (match any characters except /)
+            const globPattern = pattern
+                .replace(/\./g, "\\.")
+                .replace(/\*\*/g, "<!DOUBLESTAR!>")  // Temporarily replace ** with placeholder
+                .replace(/\*/g, "[^/]*")             // Single * matches any characters except /
+                .replace(/<!DOUBLESTAR!>/g, ".*")    // ** matches any characters including /
+                .replace(/\?/g, ".");
+            const regex = new RegExp(`^${globPattern}$`, "i");
+            return regex.test(filename);
+        } catch (e) {
+            console.error(`Invalid pattern: ${pattern}`, e);
+            return false;
+        }
+    }
+
+    private isRegexPattern(pattern: string): boolean {
+        return (pattern.startsWith("/") && pattern.endsWith("/"))
+            || (pattern.startsWith("r/") && pattern.endsWith("/"))
+            || pattern.startsWith("regex:");
+    }
+
+    private isPlainFolderPattern(pattern: string): boolean {
+        if (!pattern) {
+            return false;
+        }
+
+        return !pattern.includes("*")
+            && !pattern.includes("?")
+            && !this.isRegexPattern(pattern);
     }
 
     async processSubfolderVariables(

--- a/src/FolderSuggest.ts
+++ b/src/FolderSuggest.ts
@@ -1,0 +1,62 @@
+import { AbstractInputSuggest, App, TFolder } from 'obsidian';
+
+type InputSuggestBaseInstance = {
+    app: App;
+    close(): void;
+};
+
+type InputSuggestBaseConstructor = new (
+    app: App,
+    inputEl: HTMLInputElement,
+) => InputSuggestBaseInstance;
+
+const folderSuggestBase = (AbstractInputSuggest ?? class {
+    app: App;
+
+    constructor(app: App, _inputEl: HTMLInputElement) {
+        this.app = app;
+    }
+
+    close(): void {}
+}) as unknown as InputSuggestBaseConstructor;
+
+export class FolderSuggest extends folderSuggestBase {
+    private inputEl: HTMLInputElement;
+
+    constructor(app: App, inputEl: HTMLInputElement) {
+        super(app, inputEl);
+        this.inputEl = inputEl;
+    }
+
+    getSuggestions(query: string): TFolder[] {
+        const lowerQuery = query.toLowerCase();
+        const folders = this.app.vault.getAllLoadedFiles().filter((file): file is TFolder => file instanceof TFolder);
+
+        if (!lowerQuery) {
+            return folders;
+        }
+
+        return folders.filter((folder) => folder.path.toLowerCase().includes(lowerQuery));
+    }
+
+    renderSuggestion(folder: TFolder, el: HTMLElement): void {
+        el.setText(folder.path);
+    }
+
+    selectSuggestion(folder: TFolder): void {
+        this.inputEl.value = folder.path;
+
+        const triggerableInput = this.inputEl as HTMLInputElement & {
+            trigger?: (eventName: string) => void;
+        };
+
+        if (typeof triggerableInput.trigger === 'function') {
+            triggerableInput.trigger('input');
+        } else {
+            this.inputEl.dispatchEvent(new Event('input', { bubbles: true }));
+            this.inputEl.dispatchEvent(new Event('change', { bubbles: true }));
+        }
+
+        this.close();
+    }
+}

--- a/src/ImageConverterSettings.ts
+++ b/src/ImageConverterSettings.ts
@@ -174,6 +174,7 @@ export interface ImageConverterSettings {
     ProcessCurrentNoteskipImagesInTargetFormat: boolean;
     ProcessCurrentNoteEnlargeOrReduce: 'Always' | 'Reduce' | 'Enlarge';
     ProcessCurrentNoteSkipFormats: string;
+    ProcessCurrentNoteIgnoreFolders: string;
 
     ProcessAllVaultconvertTo: string;
     ProcessAllVaultquality: number;
@@ -359,6 +360,7 @@ export const DEFAULT_SETTINGS: ImageConverterSettings = {
     ProcessCurrentNoteskipImagesInTargetFormat: false,
     ProcessCurrentNoteEnlargeOrReduce: 'Always',
     ProcessCurrentNoteSkipFormats: 'tif,tiff,heic',
+    ProcessCurrentNoteIgnoreFolders: '',
 
     ProcessAllVaultconvertTo: "disabled",
     ProcessAllVaultquality: 0.75,

--- a/src/ProcessCurrentNote.ts
+++ b/src/ProcessCurrentNote.ts
@@ -1,3 +1,4 @@
+/* eslint-disable obsidianmd/ui/sentence-case */
 // ProcessCurrentNote.ts
 import {
     App,
@@ -8,6 +9,7 @@ import {
     TFile,
     TextComponent
 } from "obsidian";
+import { FolderSuggest } from "./FolderSuggest";
 import ImageConverterPlugin from './main';
 
 // import {
@@ -49,178 +51,347 @@ export class ProcessCurrentNote extends Modal {
     // We keep this method async to allow await inside, so we disable the no-misused-promises rule here.
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
     async onOpen(): Promise<void> {
-        const { contentEl } = this;
+		const { contentEl } = this;
 
-        // Create main container
-        const mainContainer = contentEl.createDiv({ cls: 'image-convert-modal' });
+		// Create main container
+		const mainContainer = contentEl.createDiv({
+			cls: "image-convert-modal",
+		});
 
-        // Header section
-        const headerContainer = mainContainer.createDiv({ cls: 'modal-header' });
-        headerContainer.createEl('h2', { text: 'Convert, compress and resize' });
+		// Header section
+		const headerContainer = mainContainer.createDiv({
+			cls: "modal-header",
+		});
+		headerContainer.createEl("h2", {
+			text: "Convert, compress and resize",
+		});
 
-        headerContainer.createEl('h6', {
-            text: `all images in: ${this.activeFile.basename}.${this.activeFile.extension}`,
-            cls: 'modal-subtitle'
-        });
+		headerContainer.createEl("h6", {
+			text: `all images in: ${this.activeFile.basename}.${this.activeFile.extension}`,
+			cls: "modal-subtitle",
+		});
 
-        // Initial image counts (fetch these before creating settings)
-        await this.updateImageCounts();
+		// Initial image counts (fetch these before creating settings)
+		await this.updateImageCounts();
 
-        // --- Image Counts Display ---
-        const countsDisplay = contentEl.createDiv({ cls: 'image-counts-display' });
+		// --- Image Counts Display ---
+		const countsDisplay = contentEl.createDiv({
+			cls: "image-counts-display",
+		});
 
-        countsDisplay.createEl('span', { text: 'Total images found: ' });
-        this.imageCountDisplay = countsDisplay.createEl('span');
+		countsDisplay.createEl("span", { text: "Total images found: " });
+		this.imageCountDisplay = countsDisplay.createEl("span");
 
-        countsDisplay.createEl('br');
+		countsDisplay.createEl("br");
 
-        countsDisplay.createEl('span', { text: 'To be processed: ' });
-        this.processedCountDisplay = countsDisplay.createEl('span');
+		countsDisplay.createEl("span", { text: "To be processed: " });
+		this.processedCountDisplay = countsDisplay.createEl("span");
 
-        countsDisplay.createEl('br');
+		countsDisplay.createEl("br");
 
-        countsDisplay.createEl('span', { text: 'Skipped: ' });
-        this.skippedCountDisplay = countsDisplay.createEl('span');
+		countsDisplay.createEl("span", { text: "Skipped: " });
+		this.skippedCountDisplay = countsDisplay.createEl("span");
 
-        // Warning message
-        headerContainer.createEl('p', {
-            cls: 'modal-warning',
-            // eslint-disable-next-line obsidianmd/ui/sentence-case
-            text: '⚠️ This will modify all images in the current note — please ensure you have backups.'
-        });
+		// Warning message
+		headerContainer.createEl("p", {
+			cls: "modal-warning",
+			 
+			text: "⚠️ This will modify all images in the current note — please ensure you have backups.",
+		});
 
-        // --- Settings Container ---
-        const settingsContainer = mainContainer.createDiv({ cls: 'settings-container' });
+		// --- Settings Container ---
+		const settingsContainer = mainContainer.createDiv({
+			cls: "settings-container",
+		});
 
-        // Format and Quality Container
-        const formatQualityContainer = settingsContainer.createDiv({ cls: 'format-quality-container' });
+		// Format and Quality Container
+		const formatQualityContainer = settingsContainer.createDiv({
+			cls: "format-quality-container",
+		});
 
-        // Convert To setting
-        this.convertToSetting = new Setting(formatQualityContainer)
-            .setName('Convert to ⓘ ')
-            .setDesc('Choose output format for your images')
-            .setTooltip('Same as original: preserves current format while applying compression/resizing')
-            .addDropdown(dropdown =>
-                dropdown
-                    .addOptions({
-                        disabled: 'Same as original',
-                        webp: 'WebP',
-                        jpg: 'JPG',
-                        png: 'PNG'
-                    })
-                    .setValue(this.plugin.settings.ProcessCurrentNoteconvertTo)
-                    .onChange(async value => {
-                        this.plugin.settings.ProcessCurrentNoteconvertTo = value;
-                        await this.plugin.saveSettings();
-                        await this.updateImageCountsAndDisplay(); // Update counts after changing this setting
-                    })
-            );
+		// Convert To setting
+		this.convertToSetting = new Setting(formatQualityContainer)
+			.setName("Convert to ⓘ ")
+			.setDesc("Choose output format for your images")
+			.setTooltip(
+				"Same as original: preserves current format while applying compression/resizing",
+			)
+			.addDropdown((dropdown) =>
+				dropdown
+					.addOptions({
+						disabled: "Same as original",
+						webp: "WebP",
+						jpg: "JPG",
+						png: "PNG",
+					})
+					.setValue(this.plugin.settings.ProcessCurrentNoteconvertTo)
+					.onChange(async (value) => {
+						this.plugin.settings.ProcessCurrentNoteconvertTo =
+							value;
+						await this.plugin.saveSettings();
+						await this.updateImageCountsAndDisplay(); // Update counts after changing this setting
+					}),
+			);
 
-        // Quality setting
-        new Setting(formatQualityContainer)
-            .setName('Quality ⓘ')
-            .setDesc('Compression level (0-100)')
-            .setTooltip('100: no compression (original quality)\n75: recommended (good balance)\n0-50: high compression (lower quality)')
-            .addText(text =>
-                text
-                    .setPlaceholder('Enter quality (0-100)')
-                    .setValue((this.plugin.settings.ProcessCurrentNotequality * 100).toString())
-                    .onChange(async value => {
-                        const quality = parseInt(value);
-                        if (/^\d+$/.test(value) && quality >= 0 && quality <= 100) {
-                            this.plugin.settings.ProcessCurrentNotequality = quality / 100;
-                            await this.plugin.saveSettings();
-                        }
-                    })
-            );
+		// Quality setting
+		new Setting(formatQualityContainer)
+			.setName("Quality ⓘ")
+			.setDesc("Compression level (0-100)")
+			.setTooltip(
+				"100: no compression (original quality)\n75: recommended (good balance)\n0-50: high compression (lower quality)",
+			)
+			.addText((text) =>
+				text
+					.setPlaceholder("Enter quality (0-100)")
+					.setValue(
+						(
+							this.plugin.settings.ProcessCurrentNotequality * 100
+						).toString(),
+					)
+					.onChange(async (value) => {
+						const quality = parseInt(value);
+						if (
+							/^\d+$/.test(value) &&
+							quality >= 0 &&
+							quality <= 100
+						) {
+							this.plugin.settings.ProcessCurrentNotequality =
+								quality / 100;
+							await this.plugin.saveSettings();
+						}
+					}),
+			);
 
-        // Resize Container (separate from format/quality)
-        const resizeContainer = settingsContainer.createDiv({ cls: 'resize-container' });
+		// Resize Container (separate from format/quality)
+		const resizeContainer = settingsContainer.createDiv({
+			cls: "resize-container",
+		});
 
-        // Resize Mode setting
-        this.resizeModeSetting = new Setting(resizeContainer)
-            .setName('Resize mode ⓘ')
-            .setDesc('Choose how images should be resized — results are permanent.')
-            // eslint-disable-next-line obsidianmd/ui/sentence-case
-            .setTooltip('Fit: maintains aspect ratio within dimensions\nFill: exactly matches dimensions\nLongest edge: limits the longest side\nShortest edge: limits the shortest side\nWidth/height: constrains single dimension')
-            .addDropdown(dropdown =>
-                dropdown
-                    .addOptions({
-                        None: 'None',
-                        LongestEdge: 'Longest edge',
-                        ShortestEdge: 'Shortest edge',
-                        Width: 'Width',
-                        Height: 'Height',
-                        Fit: 'Fit',
-                        Fill: 'Fill',
-                    })
-                    .setValue(this.plugin.settings.ProcessCurrentNoteResizeModalresizeMode)
-                    .onChange(async value => {
-                        this.plugin.settings.ProcessCurrentNoteResizeModalresizeMode = value;
-                        await this.plugin.saveSettings();
-                        this.updateResizeInputVisibility(value);
-                        await this.updateImageCountsAndDisplay(); // Update counts after changing this setting
-                    })
-            );
+		// Resize Mode setting
+		this.resizeModeSetting = new Setting(resizeContainer)
+			.setName("Resize mode ⓘ")
+			.setDesc(
+				"Choose how images should be resized - results are permanent.",
+			)
+			 
+			.setTooltip(
+				"Fit: maintains aspect ratio within dimensions\nFill: exactly matches dimensions\nLongest edge: limits the longest side\nShortest edge: limits the shortest side\nWidth/height: constrains single dimension",
+			)
+			.addDropdown((dropdown) =>
+				dropdown
+					.addOptions({
+						None: "None",
+						LongestEdge: "Longest edge",
+						ShortestEdge: "Shortest edge",
+						Width: "Width",
+						Height: "Height",
+						Fit: "Fit",
+						Fill: "Fill",
+					})
+					.setValue(
+						this.plugin.settings
+							.ProcessCurrentNoteResizeModalresizeMode,
+					)
+					.onChange(async (value) => {
+						this.plugin.settings.ProcessCurrentNoteResizeModalresizeMode =
+							value;
+						await this.plugin.saveSettings();
+						this.updateResizeInputVisibility(value);
+						await this.updateImageCountsAndDisplay(); // Update counts after changing this setting
+					}),
+			);
 
-        // Create resize inputs
-        this.resizeInputsDiv = resizeContainer.createDiv({ cls: 'resize-inputs' });
-        this.enlargeReduceDiv = resizeContainer.createDiv({ cls: 'enlarge-reduce-settings' });
+		// Create resize inputs
+		this.resizeInputsDiv = resizeContainer.createDiv({
+			cls: "resize-inputs",
+		});
+		this.enlargeReduceDiv = resizeContainer.createDiv({
+			cls: "enlarge-reduce-settings",
+		});
 
-        // Skip formats Container
-        const skipContainer = settingsContainer.createDiv({ cls: 'skip-container' });
+		// Skip formats Container
+		const skipContainer = settingsContainer.createDiv({
+			cls: "skip-container",
+		});
 
-        // Skip formats setting
-        this.skipFormatsSetting = new Setting(skipContainer)
-            .setName('Skip file formats ⓘ')
-            .setTooltip('Comma-separated list of file formats to skip (e.g., tif,tiff,heic). Leave empty to process all formats.')
-            .addText(text =>
-                text
-                    // eslint-disable-next-line obsidianmd/ui/sentence-case
-                    .setPlaceholder('e.g., tif, tiff, heic')
-                    .setValue(this.plugin.settings.ProcessCurrentNoteSkipFormats)
-                    .onChange(async value => {
-                        this.plugin.settings.ProcessCurrentNoteSkipFormats = value;
-                        await this.plugin.saveSettings();
-                        await this.updateImageCountsAndDisplay(); // Update counts after changing this setting
-                    })
-            );
+		// Skip formats setting
+		this.skipFormatsSetting = new Setting(skipContainer)
+			.setName("Skip file formats ⓘ")
+			.setTooltip(
+				"Comma-separated list of file formats to skip (e.g., tif,tiff,heic). Leave empty to process all formats.",
+			)
+			.addText((text) =>
+				text
+					 
+					.setPlaceholder("e.g., tif, tiff, heic")
+					.setValue(
+						this.plugin.settings.ProcessCurrentNoteSkipFormats,
+					)
+					.onChange(async (value) => {
+						this.plugin.settings.ProcessCurrentNoteSkipFormats =
+							value;
+						await this.plugin.saveSettings();
+						await this.updateImageCountsAndDisplay(); // Update counts after changing this setting
+					}),
+			);
 
-        // Skip target format setting
-        this.skipTargetFormatSetting = new Setting(skipContainer)
-            .setName('Skip images in target format ⓘ')
-            .setTooltip('If image is already in target format, this allows you to skip its compression, conversion and resizing. Processing of all other formats will be still performed.')
-            .addToggle(toggle =>
-                toggle
-                    .setValue(this.plugin.settings.ProcessCurrentNoteskipImagesInTargetFormat)
-                    .onChange(async value => {
-                        this.plugin.settings.ProcessCurrentNoteskipImagesInTargetFormat = value;
-                        await this.plugin.saveSettings();
-                        await this.updateImageCountsAndDisplay(); // Update counts after changing this setting
-                    })
-            );
+		// Ignore folders setting
+		new Setting(skipContainer)
+			.setClass("image-converter-ignore-folders-setting")
+			.setName("Skip folders ⓘ")
+			.setTooltip(
+				"Comma-separated folder patterns to exclude images from processing.",
+			)
+			.addText((text) => {
+				text.setPlaceholder("e.g., _attachments, images/**")
+					.setValue(
+						this.plugin.settings.ProcessCurrentNoteIgnoreFolders,
+					)
+					.onChange(async (value) => {
+						this.plugin.settings.ProcessCurrentNoteIgnoreFolders =
+							value;
+						await this.plugin.saveSettings();
+						await this.updateImageCountsAndDisplay();
+					});
 
-        // Initialize resize inputs
-        this.updateResizeInputVisibility(this.plugin.settings.ProcessCurrentNoteResizeModalresizeMode);
+				text.inputEl.setAttr("spellcheck", "false");
+				new FolderSuggest(this.app, text.inputEl);
+			});
 
-        // --- Update Counts After Settings Change ---
-        await this.updateImageCountsAndDisplay();
+		// Add collapsible help section below the setting row so the input stays visually anchored.
+		const helpDetails = skipContainer.createEl("details", {
+			cls: "image-converter-ignore-folders-help",
+		});
+		helpDetails.createEl("summary", {
+			text: "Show examples and how matching works",
+			cls: "image-converter-ignore-folders-help-summary",
+		});
 
-        // Submit button
-        const buttonContainer = settingsContainer.createDiv({ cls: 'button-container' });
-        this.submitButton = new ButtonComponent(buttonContainer)
-            .setButtonText('Submit')
-            .onClick(async () => { // Use async here
-                this.close();
-                if (this.activeFile.extension === 'md' || this.activeFile.extension === 'canvas') {
-                    await this.batchImageProcessor.processImagesInNote(this.activeFile);
-                    await this.refreshActiveNote();
-                } else {
-                    // eslint-disable-next-line obsidianmd/ui/sentence-case
-                    new Notice('Error: active file must be a markdown or canvas file.');
-                }
-            });
-    }
+		const helpContent = helpDetails.createDiv({
+			cls: "image-converter-ignore-folders-help-content",
+		});
+
+		helpContent.createDiv({
+			text: "How matching works:",
+			attr: { style: "font-weight: bold; margin: 8px 0 4px 0;" },
+		});
+		const behaviorList = helpContent.createEl("ul", {
+			attr: { style: "margin: 4px 0; padding-left: 20px;" },
+		});
+		behaviorList.createEl("li", {
+			text: "Folder paths without wildcards skip that folder and all subfolders",
+		});
+		behaviorList.createEl("li", {
+			text: "Leading / is optional",
+		});
+		behaviorList.createEl("li", {
+			text: "Use * to match only direct children",
+		});
+		behaviorList.createEl("li", {
+			text: "Use ** to include subfolders too",
+		});
+		behaviorList.createEl("li", {
+			text: "Regex is supported for advanced patterns",
+		});
+
+		helpContent.createDiv({
+			text: "Examples:",
+			attr: { style: "font-weight: bold; margin-bottom: 4px;" },
+		});
+
+		const examplesList = helpContent.createEl("ul", {
+			attr: { style: "margin: 4px 0 8px 0; padding-left: 20px;" },
+		});
+		examplesList.createEl("li", {
+			text: "_attachments → Skips that folder and everything inside it",
+		});
+		examplesList.createEl("li", {
+			text: "/_attachments → Same as above",
+		});
+		examplesList.createEl("li", {
+			text: "_attachments/* → Skips only direct children in that folder",
+		});
+		examplesList.createEl("li", {
+			text: "_attachments/** → Skips that folder and all nested subfolders",
+		});
+		examplesList.createEl("li", {
+			text: "images/**, assets/** → Skips multiple folder trees",
+		});
+		examplesList.createEl("li", {
+			text: "archive/2025/** → Skips a specific folder tree",
+		});
+
+		helpContent.createDiv({
+			text: "Advanced (regex):",
+			attr: { style: "font-weight: bold; margin-bottom: 4px;" },
+		});
+
+		const advancedExamplesList = helpContent.createEl("ul", {
+			attr: { style: "margin: 4px 0 8px 0; padding-left: 20px;" },
+		});
+		advancedExamplesList.createEl("li", {
+			text: "/^_attachments\\// → Skips paths starting with _attachments/",
+		});
+		advancedExamplesList.createEl("li", {
+			text: "regex:^media/(raw|temp)/ → Skips media/raw and media/temp",
+		});
+		advancedExamplesList.createEl("li", {
+			text: "r/^(drafts|scratch)\\// → Skips drafts/ and scratch/",
+		});
+
+		// Skip target format setting
+		this.skipTargetFormatSetting = new Setting(skipContainer)
+			.setName("Skip images in target format ⓘ")
+			.setTooltip(
+				"If image is already in target format, this allows you to skip its compression, conversion and resizing. Processing of all other formats will be still performed.",
+			)
+			.addToggle((toggle) =>
+				toggle
+					.setValue(
+						this.plugin.settings
+							.ProcessCurrentNoteskipImagesInTargetFormat,
+					)
+					.onChange(async (value) => {
+						this.plugin.settings.ProcessCurrentNoteskipImagesInTargetFormat =
+							value;
+						await this.plugin.saveSettings();
+						await this.updateImageCountsAndDisplay(); // Update counts after changing this setting
+					}),
+			);
+
+		// Initialize resize inputs
+		this.updateResizeInputVisibility(
+			this.plugin.settings.ProcessCurrentNoteResizeModalresizeMode,
+		);
+
+		// --- Update Counts After Settings Change ---
+		await this.updateImageCountsAndDisplay();
+
+		// Submit button
+		const buttonContainer = settingsContainer.createDiv({
+			cls: "button-container",
+		});
+		this.submitButton = new ButtonComponent(buttonContainer)
+			.setButtonText("Submit")
+			.onClick(async () => {
+				// Use async here
+				this.close();
+				if (
+					this.activeFile.extension === "md" ||
+					this.activeFile.extension === "canvas"
+				) {
+					await this.batchImageProcessor.processImagesInNote(
+						this.activeFile,
+					);
+					await this.refreshActiveNote();
+				} else {
+					 
+					new Notice(
+						"Error: active file must be a markdown or canvas file.",
+					);
+				}
+			});
+	}
     
     private updateResizeInputVisibility(resizeMode: string): void {
         if (resizeMode === "None") {
@@ -252,7 +423,7 @@ export class ProcessCurrentNote extends Modal {
             .setClass('enlarge-reduce-setting')
             .setName('Enlarge or reduce ⓘ')
             .setDesc('Controls how images are adjusted relative to target size:')
-            // eslint-disable-next-line obsidianmd/ui/sentence-case
+             
             .setTooltip('• Reduce and enlarge: adjusts all images to fit specified dimensions\n• Reduce only: only shrinks images larger than target\n• Enlarge only: only enlarges images smaller than target')
             .addDropdown((dropdown) => {
                 dropdown
@@ -401,12 +572,18 @@ export class ProcessCurrentNote extends Modal {
 
         const targetFormat = this.plugin.settings.ProcessCurrentNoteconvertTo.toLowerCase();
         const skipTargetFormat = this.plugin.settings.ProcessCurrentNoteskipImagesInTargetFormat;
+        const ignoreFolders = this.plugin.settings.ProcessCurrentNoteIgnoreFolders ?? '';
+        const matchesIgnoreFolders = (filePath: string) =>
+            this.plugin.folderAndFilenameManagement.matchesPathPatterns(filePath, ignoreFolders);
 
         if (this.activeFile.extension === 'canvas') {
             const canvasData = JSON.parse(await this.app.vault.read(this.activeFile)) as CanvasData;
             const images = this.getImagePathsFromCanvas(canvasData);
             this.imageCount = images.length;
             this.processedCount = images.filter(imagePath => {
+                if (matchesIgnoreFolders(imagePath)) {
+                    return false;
+                }
                 const imageFile = this.app.vault.getAbstractFileByPath(imagePath);
                 if (!(imageFile instanceof TFile) || skipFormats.includes(imageFile.extension.toLowerCase())) {
                     return false; // Skip if not a TFile or in skipFormats
@@ -423,6 +600,9 @@ export class ProcessCurrentNote extends Modal {
             this.imageCount = linkedFiles.length;
 
             this.processedCount = linkedFiles.filter(file => {
+                if (matchesIgnoreFolders(file.path)) {
+                    return false;
+                }
                 if (skipFormats.includes(file.extension.toLowerCase())) {
                     return false;
                 }

--- a/styles.css
+++ b/styles.css
@@ -2919,6 +2919,24 @@ button.image-converter-encoder-detected:hover,
 	border-radius: 4px;
 }
 
+.image-convert-modal .image-converter-ignore-folders-help {
+	margin: -0.35rem 0 0.75rem;
+}
+
+.image-convert-modal .image-converter-ignore-folders-help-summary {
+	cursor: pointer;
+	color: var(--text-muted);
+	font-size: 0.9em;
+}
+
+.image-convert-modal .image-converter-ignore-folders-help-content {
+	margin-top: 8px;
+	padding-left: 12px;
+	border-left: 2px solid var(--background-modifier-border);
+	color: var(--text-muted);
+	font-size: 0.9em;
+}
+
 /* ============================================ */
 /* COMPACT SINGLE-COLUMN LAYOUT STYLES */
 /* ============================================ */

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -100,6 +100,21 @@ export class PluginSettingTab {
   hide() {}
 }
 
+export class AbstractInputSuggest<T> {
+  app: App;
+  inputEl: HTMLInputElement;
+
+  constructor(app: App, inputEl: HTMLInputElement) {
+    this.app = app;
+    this.inputEl = inputEl;
+  }
+
+  getSuggestions(_query: string): T[] { return []; }
+  renderSuggestion(_value: T, _el: HTMLElement): void {}
+  selectSuggestion(_value: T): void {}
+  close(): void {}
+}
+
 // UI Components and helpers
 export class ButtonComponent {
   buttonEl: HTMLButtonElement;

--- a/tests/integration/scope/ProcessCurrentNote.test.ts
+++ b/tests/integration/scope/ProcessCurrentNote.test.ts
@@ -5,11 +5,19 @@ import ImageConverterPlugin from '../../../src/main';
 import { App, TFile } from 'obsidian';
 import { fakeApp, fakeVault, fakeTFile } from '../../factories/obsidian';
 import { BatchImageProcessor } from '../../../src/BatchImageProcessor';
+import { FolderAndFilenameManagement } from '../../../src/FolderAndFilenameManagement';
 
-function makePlugin(app: App) {
+async function makePlugin(app: App) {
   const plugin = new ImageConverterPlugin(app, { id: 'image-converter' } as any);
   vi.spyOn(plugin as any, 'loadData').mockResolvedValue(undefined);
-  return plugin.loadSettings().then(() => plugin);
+  await plugin.loadSettings();
+  (plugin as any).folderAndFilenameManagement = new FolderAndFilenameManagement(
+    app as any,
+    plugin.settings,
+    { isSupported: vi.fn(() => true) } as any,
+    {} as any,
+  );
+  return plugin;
 }
 
 describe('ProcessCurrentNote discovery and counts (Phase 7: 9.1–9.8 subset)', () => {
@@ -17,7 +25,7 @@ describe('ProcessCurrentNote discovery and counts (Phase 7: 9.1–9.8 subset)', 
     // Files
     const note = fakeTFile({ path: 'notes/n.md' });
     const canvas = fakeTFile({ path: 'boards/board.canvas', extension: 'canvas', name: 'board.canvas' });
-    const aPng = fakeTFile({ path: 'images/a.png' });
+    const aPng = fakeTFile({ path: 'attachments/a.png' });
     const bJpg = fakeTFile({ path: 'images/b.jpg' });
     const cGif = fakeTFile({ path: 'images/c.gif' });
 
@@ -25,7 +33,10 @@ describe('ProcessCurrentNote discovery and counts (Phase 7: 9.1–9.8 subset)', 
     const app = fakeApp({ vault, metadataCache: { resolvedLinks: { [note.path]: { [aPng.path]: 1, [bJpg.path]: 1, [cGif.path]: 1 } } as any } }) as any;
 
     // Seed markdown content not required because ProcessCurrentNote uses resolvedLinks for markdown, and reads canvas JSON
-    await (vault as any).modify(canvas, JSON.stringify({ nodes: [ { id: '1', type: 'file', file: 'images/a.png' } ] }));
+    await (vault as any).modify(canvas, JSON.stringify({ nodes: [
+      { id: '1', type: 'file', file: 'attachments/a.png' },
+      { id: '2', type: 'file', file: 'images/b.jpg' }
+    ] }));
 
     const plugin = await makePlugin(app as any);
     // Provide supportedImageFormats for filtering
@@ -36,6 +47,7 @@ describe('ProcessCurrentNote discovery and counts (Phase 7: 9.1–9.8 subset)', 
     plugin.settings.ProcessCurrentNoteconvertTo = 'jpg';
     plugin.settings.ProcessCurrentNoteskipImagesInTargetFormat = true;
     plugin.settings.ProcessCurrentNoteSkipFormats = 'gif';
+    plugin.settings.ProcessCurrentNoteIgnoreFolders = 'attachments/**';
 
     const processor = { processImagesInNote: vi.fn() } as unknown as BatchImageProcessor;
 
@@ -51,9 +63,9 @@ describe('ProcessCurrentNote discovery and counts (Phase 7: 9.1–9.8 subset)', 
 
     // Total includes png, jpg, gif -> 3
     expect(Number(totalTextMd)).toBe(3);
-    // Skip jpg (target) and gif (skipFormats) -> processed only png
-    expect(Number(processedTextMd)).toBe(1);
-    expect(Number(skippedTextMd)).toBe(2);
+    // Skip ignored attachments + jpg (target) + gif (skipFormats) -> processed none
+    expect(Number(processedTextMd)).toBe(0);
+    expect(Number(skippedTextMd)).toBe(3);
 
     // Open modal for canvas file
     const modalCv = new ProcessCurrentNote(app as any, plugin as any, canvas as TFile, processor);
@@ -64,9 +76,55 @@ describe('ProcessCurrentNote discovery and counts (Phase 7: 9.1–9.8 subset)', 
     const totalTextCv = totalsCv[1].textContent || '0';
     const processedTextCv = totalsCv[3].textContent || '0';
 
-    // Canvas had one linked png -> total 1, processed 1 under current skip rules
-    expect(Number(totalTextCv)).toBe(1);
-    expect(Number(processedTextCv)).toBe(1);
+    // Canvas had one linked jpg after ignoring attachments -> total 2, processed 0 (skip target and ignored)
+    expect(Number(totalTextCv)).toBe(2);
+    expect(Number(processedTextCv)).toBe(0);
+  });
+
+  it('keeps true root files processable when skip folders targets /_attachments/**', async () => {
+    const note = fakeTFile({ path: '2025-12-16.md' });
+    const rootWebp = fakeTFile({ path: '2025-12-16-1769210898077.webp' });
+    const attachmentWebp = fakeTFile({ path: '_attachments/Pasted image 20251006192757.webp' });
+    const nestedAttachmentWebp = fakeTFile({ path: '_attachments/subfolder1/Pasted image 20251006190944.webp' });
+
+    const vault = fakeVault({ files: [note, rootWebp, attachmentWebp, nestedAttachmentWebp] }) as any;
+    const app = fakeApp({
+      vault,
+      metadataCache: {
+        resolvedLinks: {
+          [note.path]: {
+            [rootWebp.path]: 1,
+            [attachmentWebp.path]: 1,
+            [nestedAttachmentWebp.path]: 1
+          }
+        }
+      } as any
+    }) as any;
+
+    const plugin = await makePlugin(app as any);
+    (plugin as any).supportedImageFormats = {
+      isSupported: vi.fn((_mime?: string, name?: string) => /\.(png|jpg|jpeg|webp|gif)$/i.test(name || ''))
+    };
+
+    plugin.settings.ProcessCurrentNoteconvertTo = 'webp';
+    plugin.settings.ProcessCurrentNotequality = 0.75;
+    plugin.settings.ProcessCurrentNoteResizeModalresizeMode = 'None';
+    plugin.settings.ProcessCurrentNoteskipImagesInTargetFormat = false;
+    plugin.settings.ProcessCurrentNoteSkipFormats = 'tif,tiff,heic';
+    plugin.settings.ProcessCurrentNoteIgnoreFolders = '/_attachments/**';
+
+    const processor = { processImagesInNote: vi.fn() } as unknown as BatchImageProcessor;
+    const modal = new ProcessCurrentNote(app as any, plugin as any, note as TFile, processor);
+    await modal.onOpen();
+
+    const totals = ((modal as any).contentEl as HTMLElement).querySelectorAll('.image-counts-display span');
+    const totalText = totals[1].textContent || '0';
+    const processedText = totals[3].textContent || '0';
+    const skippedText = totals[5].textContent || '0';
+
+    expect(Number(totalText)).toBe(3);
+    expect(Number(processedText)).toBe(1);
+    expect(Number(skippedText)).toBe(2);
   });
 
   it('9.2 Wikilink discovery includes corresponding TFiles', async () => {

--- a/tests/unit/pathing/FolderAndFilenameManagement.test.ts
+++ b/tests/unit/pathing/FolderAndFilenameManagement.test.ts
@@ -202,6 +202,34 @@ describe('FolderAndFilenameManagement conflicts and rename/convert skip rules', 
 });
 
 // -----------------------------------------------------------------------------
+// 2.5) Ignore folder path patterns
+// -----------------------------------------------------------------------------
+
+describe('FolderAndFilenameManagement.matchesPathPatterns', () => {
+  it('handles folder glob prefixes without matching root files', () => {
+    const { ffm } = makeFFMGeneric();
+
+    expect(ffm.matchesPathPatterns('2025-12-16-1769210898077.webp', '/_attachments/**')).toBe(false);
+    expect(ffm.matchesPathPatterns('_attachments/Pasted image.webp', '/_attachments/**')).toBe(true);
+    expect(ffm.matchesPathPatterns('_attachments/subfolder1/Pasted image.webp', '/_attachments/**')).toBe(true);
+  });
+
+  it('accepts leading ./ in ignore patterns and paths', () => {
+    const { ffm } = makeFFMGeneric();
+
+    expect(ffm.matchesPathPatterns('./_attachments/photo.webp', './_attachments/**')).toBe(true);
+    expect(ffm.matchesPathPatterns('./photo.webp', './_attachments/**')).toBe(false);
+  });
+
+  it('preserves regex-style path patterns that start with /', () => {
+    const { ffm } = makeFFMGeneric();
+
+    expect(ffm.matchesPathPatterns('_attachments/photo.webp', '/^_attachments\//')).toBe(true);
+    expect(ffm.matchesPathPatterns('photo.webp', '/^_attachments\//')).toBe(false);
+  });
+});
+
+// -----------------------------------------------------------------------------
 // 3) getImagePath resolution
 // -----------------------------------------------------------------------------
 describe('FolderAndFilenameManagement.getImagePath', () => {


### PR DESCRIPTION
### TL;DR

Added folder exclusion functionality to the batch image processor, allowing users to skip images in specific folders during processing.

### What changed?

- Added `ProcessCurrentNoteIgnoreFolders` setting to exclude folders from image processing
- Enhanced `FolderAndFilenameManagement` with `matchesPathPatterns()` method supporting glob patterns, regex, and folder hierarchies
- Created `FolderSuggest` component for autocompleting folder paths in the UI
- Added folder filtering logic to `BatchImageProcessor` that respects the ignore patterns
- Updated the Process Current Note modal with a new "Skip folders" setting including collapsible help documentation

### How to test?

1. Open the "Process Current Note" modal on a note with images in various folders
2. Enter folder patterns in the "Skip folders" field (e.g., `_attachments/**`, `images/temp`)
3. Verify the image counts update to exclude images from specified folders
4. Test different pattern types: plain folders, glob patterns with `*` and `**`, and regex patterns
5. Confirm that folder autocomplete suggestions appear when typing

### Why make this change?

This addresses the need to selectively exclude certain folders (like temporary directories, archives, or specific attachment folders) from batch image processing operations, giving users more granular control over which images get processed while maintaining the existing functionality for included folders.